### PR TITLE
hwinfo: remove volatile pointer type casts from base addresses

### DIFF
--- a/drivers/cadence_uart.c
+++ b/drivers/cadence_uart.c
@@ -116,7 +116,7 @@
 #define cdns_uart_readl(offset)		(*((volatile uint32_t *)baseaddr + (offset/4)))
 #define cdns_uart_writel(val, offset)	do { *((volatile uint32_t *)baseaddr + (offset/4)) = val; } while (0)
 
-static volatile uint32_t *baseaddr = 0x0;
+static uintptr_t baseaddr = 0x0;
 
 /**
  * cdns_uart_startup - Called when an application opens a cdns_uart port
@@ -124,7 +124,7 @@ static volatile uint32_t *baseaddr = 0x0;
  *
  * Return: 0 on success, negative errno otherwise
  */
-int cdns_uart_startup(volatile uint32_t *base)
+int cdns_uart_startup(uintptr_t base)
 {
         int retval = 0;
 

--- a/drivers/cadence_uart.h
+++ b/drivers/cadence_uart.h
@@ -1,7 +1,7 @@
 #define putc cdns_uart_poll_put_char
 #define puts cdns_uart_poll_puts
 
-int cdns_uart_startup();
+int cdns_uart_startup(uintptr_t base);
 void cdns_uart_poll_put_char(unsigned char c);
 void cdns_uart_poll_puts(const char *c);
 

--- a/drivers/dma.c
+++ b/drivers/dma.c
@@ -1283,14 +1283,14 @@ static inline void _reset_thread(struct pl330_thread *thrd)
 	thrd->req_running = -1;
 }
 
-struct dma *dma_create(const char *name, volatile uint32_t *base,
+struct dma *dma_create(const char *name, uintptr_t base,
                        uint8_t *mcode_addr, unsigned mcode_sz)
 {
     struct pl330_dmac *d = OBJECT_ALLOC(dmas);
     if (!d)
         return NULL;
     d->name = name;
-    d->base = base;
+    d->base = (void __iomem *) base;
 
     // Microcode buffer reachable from DMA and CPU via same addr
     d->mcode_bus = mcode_addr;

--- a/drivers/dma.h
+++ b/drivers/dma.h
@@ -11,7 +11,7 @@ struct dma_tx;
 
 typedef void (*dma_cb_t)(void *arg, int rc);
 
-struct dma *dma_create(const char *name, volatile uint32_t *base,
+struct dma *dma_create(const char *name, uintptr_t base,
                        uint8_t *mcode_addr, unsigned mcode_sz);
 void dma_destroy(struct dma *dma);
 

--- a/drivers/etimer.c
+++ b/drivers/etimer.c
@@ -65,7 +65,7 @@ static const struct cmd_code cmd_codes[] = {
 
 struct etimer {
     struct object obj;
-    volatile uint32_t *base;
+    uintptr_t base;
     const char *name;
     etimer_cb_t cb;
     void *cb_arg;
@@ -87,7 +87,7 @@ static void exec_cmd(struct etimer *et, enum cmd cmd)
     REGB_WRITE32(et->base, REG__CMD_FIRE, code->fire);
 }
 
-struct etimer *etimer_create(const char *name, volatile uint32_t *base,
+struct etimer *etimer_create(const char *name, uintptr_t base,
                              etimer_cb_t cb, void *cb_arg,
                              uint32_t nominal_freq_hz, uint32_t clk_freq_hz,
                              unsigned max_div)

--- a/drivers/etimer.h
+++ b/drivers/etimer.h
@@ -18,7 +18,7 @@ enum etimer_sync_src {
 typedef void (*etimer_cb_t)(struct etimer *et, void *arg);
 
 
-struct etimer *etimer_create(const char *name, volatile uint32_t *base,
+struct etimer *etimer_create(const char *name, uintptr_t base,
                              etimer_cb_t cb, void *cb_arg,
                              uint32_t nominal_freq_hz, uint32_t clk_freq_hz,
                              unsigned max_div);

--- a/drivers/gic.c
+++ b/drivers/gic.c
@@ -61,7 +61,7 @@ struct irq {
 };
 
 struct gic {
-    volatile uint32_t *base;
+    uintptr_t base;
     struct irq irqs[MAX_IRQS];
     unsigned nregs;
 };
@@ -221,7 +221,7 @@ static const struct intc_ops gic_ops = {
     .int_type = gic_op_int_type,
 };
 
-void gic_init(volatile uint32_t *base)
+void gic_init(uintptr_t base)
 {
     uint32_t typer = REGB_READ32(base, GICD(GICD_TYPER));
 

--- a/drivers/gic.h
+++ b/drivers/gic.h
@@ -18,7 +18,7 @@ typedef enum {
     GIC_IRQ_CFG_EDGE
 } gic_irq_cfg_t;
 
-void gic_init(volatile uint32_t *base);
+void gic_init(uintptr_t base);
 
 void gic_int_enable(unsigned irq, gic_irq_type_t type, gic_irq_cfg_t cfg);
 void gic_int_disable(unsigned irq, gic_irq_type_t type);

--- a/drivers/mailbox.h
+++ b/drivers/mailbox.h
@@ -26,7 +26,7 @@ union mbox_cb {
 
 struct mbox;
 
-struct mbox *mbox_claim(volatile uint32_t * ip_base, unsigned instance,
+struct mbox *mbox_claim(uintptr_t ip_base, unsigned instance,
                         struct irq *irq, unsigned int_idx,
                         uint32_t owner, uint32_t src, uint32_t dest,
                         enum mbox_dir dir, union mbox_cb cb, void *cb_arg);

--- a/drivers/mmu.h
+++ b/drivers/mmu.h
@@ -15,7 +15,7 @@ struct mmu;
 struct mmu_context;
 struct mmu_stream;
 
-struct mmu *mmu_create(const char *name, volatile uint32_t *base);
+struct mmu *mmu_create(const char *name, uintptr_t base);
 int mmu_destroy(struct mmu *m);
 
 struct mmu_context *mmu_context_create(struct mmu *m, struct balloc *ba, enum mmu_pagesize pgsz);

--- a/drivers/ns16550.c
+++ b/drivers/ns16550.c
@@ -287,7 +287,7 @@ int NS16550_tstc(NS16550_t com_port)
 	return (serial_in(&com_port->lsr) & UART_LSR_DR) != 0;
 }
 
-int ns16550_startup(volatile uint32_t *base, int clock, int baudrate)
+int ns16550_startup(uintptr_t base, int clock, int baudrate)
 {
 	struct ns16550_platdata *plat = &com_port.plat;
 

--- a/drivers/ns16550.h
+++ b/drivers/ns16550.h
@@ -18,5 +18,5 @@
 
 #include <stdint.h>
 
-int ns16550_startup(volatile uint32_t *base, int clock, int baudrate);
+int ns16550_startup(uintptr_t base, int clock, int baudrate);
 void ns16550_putchar(char ch);

--- a/drivers/nvic.c
+++ b/drivers/nvic.c
@@ -22,7 +22,7 @@ struct irq {
 };
 
 struct nvic {
-    volatile uint32_t *base;
+    uintptr_t base;
     struct irq irqs[MAX_IRQS];
 };
 
@@ -95,7 +95,7 @@ static const struct intc_ops nvic_ops = {
     .int_type = nvic_op_int_type,
 };
 
-void nvic_init(volatile uint32_t *scs_base)
+void nvic_init(uintptr_t scs_base)
 {
     nvic.base = scs_base;
     intc_register(&nvic_ops);

--- a/drivers/nvic.h
+++ b/drivers/nvic.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-void nvic_init(volatile uint32_t *scs_base);
+void nvic_init(uintptr_t scs_base);
 unsigned nvic_num_ints();
 
 void nvic_int_enable(unsigned irq);

--- a/drivers/rti-timer.c
+++ b/drivers/rti-timer.c
@@ -34,7 +34,7 @@ static const struct cmd_code cmd_codes[] = {
 
 struct rti_timer {
     struct object obj;
-    volatile uint32_t *base;
+    uintptr_t base;
     const char *name;
     rti_timer_cb_t *cb;
     void *cb_arg;
@@ -52,7 +52,7 @@ static void exec_cmd(struct rti_timer *tmr, enum cmd cmd)
     REGB_WRITE32(tmr->base, REG__CMD_FIRE, code->fire);
 }
 
-struct rti_timer *rti_timer_create(const char *name, volatile uint32_t *base,
+struct rti_timer *rti_timer_create(const char *name, uintptr_t base,
                                    rti_timer_cb_t *cb, void *cb_arg)
 {
     printf("RTI TMR %s: create base %p\r\n", name, base);

--- a/drivers/rti-timer.h
+++ b/drivers/rti-timer.h
@@ -7,7 +7,7 @@ struct rti_timer;
 
 typedef void (rti_timer_cb_t)(struct rti_timer *tmr, void *arg);
 
-struct rti_timer *rti_timer_create(const char *name, volatile uint32_t *base,
+struct rti_timer *rti_timer_create(const char *name, uintptr_t base,
                                    rti_timer_cb_t *cb, void *cb_arg);
 void rti_timer_destroy(struct rti_timer *tmr);
 

--- a/drivers/smc.c
+++ b/drivers/smc.c
@@ -7,7 +7,7 @@
 
 #include "smc.h"
 
-#define SMC_REG(b, r) ((volatile uint32_t *)(((volatile uint8_t *)b) + (r)))
+#define SMC_REG(b, r) ((b) + (r))
 
 #define SMC__memc_status                0x000
 #define SMC__mem_cfg_set                0x008
@@ -65,7 +65,7 @@
 #define SMC__cmd_type__ModeRegUpdateRegs        0b11
 
 struct smc {
-    volatile uint32_t *base;
+    uintptr_t base;
 };
 
 #define MAX_SMCS 2
@@ -82,7 +82,7 @@ static unsigned to_width_bits(unsigned width)
     return 0;
 }
 
-struct smc *smc_init(volatile uint32_t *base, struct smc_mem_cfg *cfg)
+struct smc *smc_init(uintptr_t base, struct smc_mem_cfg *cfg)
 {
     struct smc *s;
     s = OBJECT_ALLOC(smcs);
@@ -124,6 +124,6 @@ struct smc *smc_init(volatile uint32_t *base, struct smc_mem_cfg *cfg)
 void smc_deinit(struct smc *s)
 {
     ASSERT(s);
-    s->base = NULL;
+    s->base = 0;
     OBJECT_FREE(s);
 }

--- a/drivers/smc.h
+++ b/drivers/smc.h
@@ -28,7 +28,7 @@ struct smc_mem_cfg {
 
 struct smc;
 
-struct smc *smc_init(volatile uint32_t *base, struct smc_mem_cfg *cfg);
+struct smc *smc_init(uintptr_t base, struct smc_mem_cfg *cfg);
 void smc_deinit(struct smc *);
 
 #endif // SMC_H

--- a/drivers/wdt.c
+++ b/drivers/wdt.c
@@ -83,7 +83,7 @@ static const struct cmd_code cmd_codes[] = {
 
 struct wdt {
     struct object obj;
-    volatile uint32_t *base; 
+    uintptr_t base;
     const char *name;
     wdt_cb_t cb;
     void *cb_arg;
@@ -119,8 +119,8 @@ static void exec_stage_cmd(struct wdt *wdt, enum stage_cmd scmd, unsigned stage)
     exec_cmd(wdt, &stage_cmd_codes[stage][scmd]);
 }
 
-static struct wdt *wdt_create(const char *name, volatile uint32_t *base,
-                       wdt_cb_t cb, void *cb_arg)
+static struct wdt *wdt_create(const char *name, uintptr_t base,
+                              wdt_cb_t cb, void *cb_arg)
 {
 
     printf("WDT %s: create base %p\r\n", name, base);
@@ -133,9 +133,9 @@ static struct wdt *wdt_create(const char *name, volatile uint32_t *base,
     wdt->cb_arg = cb_arg;
     return wdt;
 }
-struct wdt *wdt_create_monitor(const char *name, volatile uint32_t *base,
-                       wdt_cb_t cb, void *cb_arg,
-                       uint32_t clk_freq_hz, unsigned max_div)
+struct wdt *wdt_create_monitor(const char *name, uintptr_t base,
+                               wdt_cb_t cb, void *cb_arg,
+                               uint32_t clk_freq_hz, unsigned max_div)
 {
     struct wdt *wdt = wdt_create(name, base, cb, cb_arg);
     wdt->clk_freq_hz = clk_freq_hz;
@@ -144,8 +144,8 @@ struct wdt *wdt_create_monitor(const char *name, volatile uint32_t *base,
     wdt->monitor = true;
     return wdt;
 }
-struct wdt *wdt_create_target(const char *name, volatile uint32_t *base,
-                       wdt_cb_t cb, void *cb_arg)
+struct wdt *wdt_create_target(const char *name, uintptr_t base,
+                              wdt_cb_t cb, void *cb_arg)
 {
     struct wdt *wdt = wdt_create(name, base, cb, cb_arg);
     wdt->monitor = false;

--- a/drivers/wdt.h
+++ b/drivers/wdt.h
@@ -16,10 +16,10 @@ typedef void (*wdt_cb_t)(struct wdt *wdt, unsigned stage, void *arg);
 // board (but not of the IP block), i.e. what would be defined by the device
 // tree node, hence they are not hardcoded in the driver. To divide the
 // frequency, you would change the argument to wdt_configure, not here.
-struct wdt *wdt_create_monitor(const char *name, volatile uint32_t *base,
-                       wdt_cb_t cb, void *cb_arg,
-                       uint32_t clk_freq_hz, unsigned max_div);
-struct wdt *wdt_create_target(const char *name, volatile uint32_t *base,
+struct wdt *wdt_create_monitor(const char *name, uintptr_t base,
+                               wdt_cb_t cb, void *cb_arg,
+                               uint32_t clk_freq_hz, unsigned max_div);
+struct wdt *wdt_create_target(const char *name, uintptr_t base,
                               wdt_cb_t cb, void *cb_arg);
 void wdt_destroy(struct wdt *wdt);
 int wdt_configure(struct wdt *wdt, unsigned freq,

--- a/lib/mailbox-link.h
+++ b/lib/mailbox-link.h
@@ -11,7 +11,7 @@
 // These properties are configured externally from the mailbox driver and
 // mailbox-link library, hence the separate data structure.
 struct mbox_link_dev {
-    volatile uint32_t *base;
+    uintptr_t base;
     struct irq *rcv_irq;
     unsigned rcv_int_idx; /* interrupt index within IP block */
     struct irq *ack_irq;

--- a/lib/memfs.c
+++ b/lib/memfs.c
@@ -32,7 +32,7 @@ typedef struct {
 } global_table;
 
 struct memfs {
-    volatile uint32_t *base;
+    uintptr_t base;
     struct dma *dmac; // optional, for loading files via DMA
 };
 
@@ -92,7 +92,7 @@ static int load_memcpy(uint32_t *mem_addr, uint32_t *load_addr, unsigned size)
     return 0;
 }
 
-struct memfs *memfs_mount(volatile uint32_t *base, struct dma *dmac)
+struct memfs *memfs_mount(uintptr_t base, struct dma *dmac)
 {
     struct memfs *fs;
     fs = OBJECT_ALLOC(memfss);
@@ -105,7 +105,7 @@ struct memfs *memfs_mount(volatile uint32_t *base, struct dma *dmac)
 void memfs_unmount(struct memfs *fs)
 {
     ASSERT(fs);
-    fs->base = NULL;
+    fs->base = 0;
     fs->dmac = NULL;
     OBJECT_FREE(fs);
 }

--- a/lib/memfs.h
+++ b/lib/memfs.h
@@ -2,7 +2,7 @@
 
 struct dma;
 
-struct memfs *memfs_mount(volatile uint32_t *base, struct dma *dmac);
+struct memfs *memfs_mount(uintptr_t base, struct dma *dmac);
 void memfs_unmount(struct memfs *fs);
 
 // addr: will be set to the load addr found in the image

--- a/plat/hwinfo.h
+++ b/plat/hwinfo.h
@@ -34,9 +34,9 @@
 
 #define HPSC_MBOX_NUM_BLOCKS 3
 
-#define MBOX_LSIO__BASE           ((volatile uint32_t *)0x3000a000)
-#define MBOX_HPPS_TRCH__BASE      ((volatile uint32_t *)0xfff50000)
-#define MBOX_HPPS_RTPS__BASE      ((volatile uint32_t *)0xfff60000)
+#define MBOX_LSIO__BASE           0x3000a000
+#define MBOX_HPPS_TRCH__BASE      0xfff50000
+#define MBOX_HPPS_RTPS__BASE      0xfff60000
 
 #define WDT_SIZE_4KB              0x1000
 #define WDT_SIZE_64KB            0x10000

--- a/plat/hwinfo.h
+++ b/plat/hwinfo.h
@@ -23,7 +23,7 @@
 #define UART_CLOCK      100000000
 #define UART_BAUDRATE      125000
 
-#define ETIMER__BASE                    ((volatile uint32_t *)0x2100a000)
+#define ETIMER__BASE                    0x2100a000
 #define RTI_TIMER_TRCH__BASE            0x21009000
 #define RTI_TIMER_RTPS_R52_0__TRCH_BASE 0x21007000
 #define RTI_TIMER_RTPS_R52_1__TRCH_BASE 0x21008000

--- a/plat/hwinfo.h
+++ b/plat/hwinfo.h
@@ -17,8 +17,8 @@
 #define TRCH_DMA_BASE   0x21000000
 #define RTPS_DMA_BASE   0x30a08000
 
-#define LSIO_UART0_BASE ((volatile uint32_t*)0x30000000)
-#define LSIO_UART1_BASE ((volatile uint32_t*)0x30001000)
+#define LSIO_UART0_BASE 0x30000000
+#define LSIO_UART1_BASE 0x30001000
 
 #define UART_CLOCK      100000000
 #define UART_BAUDRATE      125000

--- a/plat/hwinfo.h
+++ b/plat/hwinfo.h
@@ -66,8 +66,8 @@
 #define HSIO_BASE               0xe3000000
 #define HSIO_SIZE               0x15000000
 
-#define SMC_BASE                ((volatile uint32_t *)0x30006000)
-#define SMC_SRAM_BASE           ((volatile uint32_t *)0x28000000)
+#define SMC_BASE                0x30006000
+#define SMC_SRAM_BASE           0x28000000
 #define SMC_SRAM_SIZE            0x8000000
 #define SMC_SRAM_BL_FS_START	((volatile uint32_t *)0x28300000)
 

--- a/plat/hwinfo.h
+++ b/plat/hwinfo.h
@@ -10,9 +10,9 @@
 #define RTPS_GIC_BASE   0x30e00000
 #define TRCH_SCS_BASE   0xe000e000
 
-#define RTPS_TRCH_TO_HPPS_SMMU_BASE   ((volatile uint32_t *)0x31100000)
-#define RTPS_SMMU_BASE                ((volatile uint32_t *)0x31000000)
-#define HPPS_SMMU_BASE                ((volatile uint32_t *)0xf9300000)
+#define RTPS_TRCH_TO_HPPS_SMMU_BASE   0x31100000
+#define RTPS_SMMU_BASE                0x31000000
+#define HPPS_SMMU_BASE                0xf9300000
 
 #define TRCH_DMA_BASE   0x21000000
 #define RTPS_DMA_BASE   0x30a08000
@@ -63,8 +63,8 @@
 #define CRL       ((volatile uint8_t *)0xff5e0000)
 #define RPU_CTRL  ((volatile uint8_t *)0xff9a0000)
 
-#define HSIO_BASE               ((volatile uint32_t *)0xe3000000)
-#define HSIO_SIZE                                     0x15000000
+#define HSIO_BASE               0xe3000000
+#define HSIO_SIZE               0x15000000
 
 #define SMC_BASE                ((volatile uint32_t *)0x30006000)
 #define SMC_SRAM_BASE           ((volatile uint32_t *)0x28000000)

--- a/plat/hwinfo.h
+++ b/plat/hwinfo.h
@@ -57,11 +57,11 @@
 #define WDT_HPPS_RTPS_BASE         0xfff70000
 #define WDT_HPPS_SIZE              WDT_SIZE_64KB
 
-#define APU       ((volatile uint8_t *)0xfd5c0000)
-#define APU1      ((volatile uint8_t *)0xfd5c1000)
-#define CRF       ((volatile uint8_t *)0xfd1a0000)
-#define CRL       ((volatile uint8_t *)0xff5e0000)
-#define RPU_CTRL  ((volatile uint8_t *)0xff9a0000)
+#define APU       0xfd5c0000
+#define APU1      0xfd5c1000
+#define CRF       0xfd1a0000
+#define CRL       0xff5e0000
+#define RPU_CTRL  0xff9a0000
 
 #define HSIO_BASE               0xe3000000
 #define HSIO_SIZE               0x15000000

--- a/plat/hwinfo.h
+++ b/plat/hwinfo.h
@@ -41,20 +41,20 @@
 #define WDT_SIZE_4KB              0x1000
 #define WDT_SIZE_64KB            0x10000
 
-#define WDT_TRCH_BASE              ((volatile uint32_t *)0x21002000)
+#define WDT_TRCH_BASE              0x21002000
 #define WDT_TRCH_SIZE              WDT_SIZE_4KB
 
-#define WDT_RTPS_R52_0_TRCH_BASE   ((volatile uint32_t *)0x21004000)
-#define WDT_RTPS_R52_1_TRCH_BASE   ((volatile uint32_t *)0x21005000)
-#define WDT_RTPS_A53_TRCH_BASE     ((volatile uint32_t *)0x21003000)
-#define WDT_RTPS_R52_0_RTPS_BASE   ((volatile uint32_t *)0x30a0a000)
-#define WDT_RTPS_R52_1_RTPS_BASE   ((volatile uint32_t *)0x30a0b000)
+#define WDT_RTPS_R52_0_TRCH_BASE   0x21004000
+#define WDT_RTPS_R52_1_TRCH_BASE   0x21005000
+#define WDT_RTPS_A53_TRCH_BASE     0x21003000
+#define WDT_RTPS_R52_0_RTPS_BASE   0x30a0a000
+#define WDT_RTPS_R52_1_RTPS_BASE   0x30a0b000
 #define WDT_RTPS_R52_SIZE          WDT_SIZE_4KB
-#define WDT_RTPS_A53_RTPS_BASE     ((volatile uint32_t *)0x30a09000)
+#define WDT_RTPS_A53_RTPS_BASE     0x30a09000
 #define WDT_RTPS_A53_SIZE          WDT_SIZE_4KB
 
-#define WDT_HPPS_TRCH_BASE         ((volatile uint32_t *)0x21010000)
-#define WDT_HPPS_RTPS_BASE         ((volatile uint32_t *)0xfff70000)
+#define WDT_HPPS_TRCH_BASE         0x21010000
+#define WDT_HPPS_RTPS_BASE         0xfff70000
 #define WDT_HPPS_SIZE              WDT_SIZE_64KB
 
 #define APU       ((volatile uint8_t *)0xfd5c0000)

--- a/plat/hwinfo.h
+++ b/plat/hwinfo.h
@@ -69,7 +69,7 @@
 #define SMC_BASE                0x30006000
 #define SMC_SRAM_BASE           0x28000000
 #define SMC_SRAM_SIZE            0x8000000
-#define SMC_SRAM_BL_FS_START	((volatile uint32_t *)0x28300000)
+#define SMC_SRAM_BL_FS_START	0x28300000
 
 // See props in Qemu device tree node (or real HW characteristics)
 #define ETIMER_NOMINAL_FREQ_HZ 1000000000

--- a/plat/hwinfo.h
+++ b/plat/hwinfo.h
@@ -24,13 +24,13 @@
 #define UART_BAUDRATE      125000
 
 #define ETIMER__BASE                    ((volatile uint32_t *)0x2100a000)
-#define RTI_TIMER_TRCH__BASE            ((volatile uint32_t *)0x21009000)
-#define RTI_TIMER_RTPS_R52_0__TRCH_BASE ((volatile uint32_t *)0x21007000)
-#define RTI_TIMER_RTPS_R52_1__TRCH_BASE ((volatile uint32_t *)0x21008000)
-#define RTI_TIMER_RTPS_A53__TRCH_BASE   ((volatile uint32_t *)0x21006000)
-#define RTI_TIMER_RTPS_R52_0__RTPS_BASE ((volatile uint32_t *)0x30a05000)
-#define RTI_TIMER_RTPS_R52_1__RTPS_BASE ((volatile uint32_t *)0x30a06000)
-#define RTI_TIMER_RTPS_A53__RTPS_BASE   ((volatile uint32_t *)0x30a04000)
+#define RTI_TIMER_TRCH__BASE            0x21009000
+#define RTI_TIMER_RTPS_R52_0__TRCH_BASE 0x21007000
+#define RTI_TIMER_RTPS_R52_1__TRCH_BASE 0x21008000
+#define RTI_TIMER_RTPS_A53__TRCH_BASE   0x21006000
+#define RTI_TIMER_RTPS_R52_0__RTPS_BASE 0x30a05000
+#define RTI_TIMER_RTPS_R52_1__RTPS_BASE 0x30a06000
+#define RTI_TIMER_RTPS_A53__RTPS_BASE   0x30a04000
 
 #define HPSC_MBOX_NUM_BLOCKS 3
 

--- a/plat/hwinfo.h
+++ b/plat/hwinfo.h
@@ -14,8 +14,8 @@
 #define RTPS_SMMU_BASE                ((volatile uint32_t *)0x31000000)
 #define HPPS_SMMU_BASE                ((volatile uint32_t *)0xf9300000)
 
-#define TRCH_DMA_BASE   ((volatile uint32_t *)0x21000000)
-#define RTPS_DMA_BASE   ((volatile uint32_t *)0x30a08000)
+#define TRCH_DMA_BASE   0x21000000
+#define RTPS_DMA_BASE   0x30a08000
 
 #define LSIO_UART0_BASE ((volatile uint32_t*)0x30000000)
 #define LSIO_UART1_BASE ((volatile uint32_t*)0x30001000)

--- a/rtps/main.c
+++ b/rtps/main.c
@@ -90,7 +90,7 @@ int main(void)
     enable_caches();
     enable_interrupts();
 
-    gic_init((volatile uint32_t *)RTPS_GIC_BASE);
+    gic_init(RTPS_GIC_BASE);
 
 #if TEST_R52_SMP
     test_r52_smp();

--- a/test/test-rti-timer.c
+++ b/test/test-rti-timer.c
@@ -21,7 +21,7 @@ static void handle_event(struct rti_timer *tmr, void *arg)
     printf("RTI TMR test: events -> %u\r\n", *events);
 }
 
-int test_rti_timer(volatile uint32_t *base, struct rti_timer **tmr_ptr)
+int test_rti_timer(uintptr_t base, struct rti_timer **tmr_ptr)
 {
     int rc = 1;
     int events = 0;

--- a/test/test-rti-timer.h
+++ b/test/test-rti-timer.h
@@ -4,6 +4,6 @@
 #include <stdint.h>
 #include "rti-timer.h"
 
-int test_rti_timer(volatile uint32_t *base, struct rti_timer **tmr_ptr);
+int test_rti_timer(uintptr_t base, struct rti_timer **tmr_ptr);
 
 #endif // TEST_RTI_TIMER_H

--- a/trch/main.c
+++ b/trch/main.c
@@ -76,7 +76,7 @@ int main ( void )
     printf("ENTER PRIVELEGED MODE: svc #0\r\n");
     asm("svc #0");
 
-    nvic_init((volatile uint32_t *)TRCH_SCS_BASE);
+    nvic_init(TRCH_SCS_BASE);
 
     sleep_set_busyloop_factor(TRCH_M4_BUSYLOOP_FACTOR);
 

--- a/trch/reset.c
+++ b/trch/reset.c
@@ -72,7 +72,7 @@ int reset_assert(comp_t comps)
         REGB_CLEAR32(RPU_CTRL, RPU_CTRL__RPU_2_CFG, RPU_CTRL__RPU_2_CFG__NCPUHALT);
 
     if (comps & COMP_CPUS_HPPS) {
-        volatile uint8_t * apu = APU;
+        volatile uint8_t * apu = (volatile uint8_t *)APU;
         uint32_t shift = COMP_CPUS_SHIFT_HPPS;
         REGB_SET32(CRF, CRF__RST_FPD_APU,
                    (CRF__RST_FPD_APU__ACPUx_RESET &
@@ -80,7 +80,7 @@ int reset_assert(comp_t comps)
                         << CRF__RST_FPD_APU__ACPUx_RESET__SHIFT)) |
                    (((comps & COMP_CPUS_HPPS) == COMP_CPUS_HPPS) ? CRF__RST_FPD_APU__GIC_RESET : 0x0));
         if (comps & COMP_CPUS_HPPS_CL1) { 
-            apu = APU1;
+            apu = (volatile uint8_t *)APU1;
             shift = COMP_CPUS_SHIFT_HPPS_CL1;
         }
         REGB_SET32(apu, APU__PWRCTL,
@@ -121,10 +121,10 @@ int reset_release(comp_t comps)
     }
 
     if (comps & COMP_CPUS_HPPS) {
-        volatile uint8_t * apu = APU;
+        volatile uint8_t * apu = (volatile uint8_t *)APU;
         uint32_t shift = COMP_CPUS_SHIFT_HPPS;
         if (comps & COMP_CPUS_HPPS_CL1) { 
-            apu = APU1;
+            apu = (volatile uint8_t *)APU1;
             shift = COMP_CPUS_SHIFT_HPPS_CL1;
         }
         REGB_CLEAR32(apu, APU__PWRCTL,

--- a/trch/tests/wdt.c
+++ b/trch/tests/wdt.c
@@ -23,7 +23,7 @@ struct wdt_info {
     // WDT instance base = group base + offset * as_size
     // Do this math at runtime, since the expressions need casts that make
     // them to long to write in the table
-    volatile uint32_t *base; // of the group
+    uintptr_t base; // of the group
     unsigned offset; // from base
     unsigned as_size;
 
@@ -186,7 +186,7 @@ cleanup:
 }
 
 static int test_wdt(struct wdt **wdt_ptr, const char *name,
-             volatile uint32_t *base, unsigned irq)
+                    uintptr_t base, unsigned irq)
 {
     printf("TEST WDT: %s: interval %u ms\r\n", name, INTERVAL_MS);
 
@@ -244,9 +244,7 @@ int test_wdts()
     for (unsigned i = 1 /* trch tested above */; i < NUM_WDTS;  ++i) {
         const struct wdt_info *wi = &wdt_info[i];
         rc |= test_wdt(&wdts[i] /* see ISR in watchdog.c */, wi->name,
-                (volatile uint32_t *)
-                ((volatile uint8_t *)wi->base + wi->offset * wi->as_size),
-                wi->irq);
+                       wi->base + wi->offset * wi->as_size, wi->irq);
        if (rc)
            return rc;
     }


### PR DESCRIPTION
These changes make the hwinfo.h header more portable.  The header is used downstream in RTEMS, and type casts do not align with the data structure and access patterns in RTEMS drivers.  Additionally, treating base addresses as `uintptr_t` in the C sources reduces complexity in both function prototypes and pointer arithmetic, only casting to appropriate volatile data types when data is actually accessed.

The changes cover a bunch of files but are actually pretty minimal since most drivers use `regops.h`, which casts appropriately when writing to registers.