### PR TITLE
Added MMU tests

### DIFF
--- a/plat/mem-map.h
+++ b/plat/mem-map.h
@@ -70,6 +70,10 @@
 #define RT_MMU_TEST_DATA_HI_1_ADDR      0x100010000
 #define RT_MMU_TEST_DATA_HI_SIZE            0x10000
 
+#define MMU_TEST_DATA_HI_0_ADDR        0x0500000000
+#define MMU_TEST_DATA_HI_1_ADDR        0x0500001000
+#define MMU_TEST_DATA_HI_SIZE              0x001000
+
 // Boot config (TODO: to be replaced by u-boot env/script)
 #define HPPS_DDR_ADDR__HPPS_SMP__BOOT_MODE 0xc001fffc
 
@@ -96,5 +100,9 @@
 
 #define RT_MMU_TEST_DATA_LO_ADDR         0xc3fff000
 #define RT_MMU_TEST_DATA_LO_SIZE           0x001000
+
+#define MMU_TEST_DATA_LO_0_ADDR          0xc2ffe000
+#define MMU_TEST_DATA_LO_1_ADDR          0xc2fff000
+#define MMU_TEST_DATA_LO_SIZE              0x001000
 
 #endif // MEM_MAP_H

--- a/trch/Makefile
+++ b/trch/Makefile
@@ -11,6 +11,8 @@ CONFIG_FLAGS = \
 	TEST_ETIMER \
 	TEST_RTI_TIMER \
 	TEST_SHMEM \
+	TEST_32_MMU_ACCESS_PHYSICAL \
+	TEST_MMU_MAPPING_SWAP \
 	CONFIG_SYSTICK \
 	CONFIG_SLEEP_TIMER \
 	CONFIG_HPPS_TRCH_MAILBOX \
@@ -146,6 +148,14 @@ OBJS += tests/dma.o
 endif
 ifeq ($(strip $(TEST_RT_MMU)),1)
 OBJS += tests/mmu.o
+endif
+ifeq ($(strip $(TEST_32_MMU_ACCESS_PHYSICAL)),1)
+OBJS += tests/mmu.o
+OBJS += mmus.o
+endif
+ifeq ($(strip $(TEST_MMU_MAPPING_SWAP)),1)
+OBJS += tests/mmu.o
+OBJS += mmus.o
 endif
 ifeq ($(strip $(TEST_WDTS)),1)
 OBJS += tests/wdt.o

--- a/trch/Makefile.defconfig
+++ b/trch/Makefile.defconfig
@@ -8,6 +8,8 @@ TEST_RT_MMU						?= 0
 TEST_ETIMER						?= 0
 TEST_RTI_TIMER					?= 0
 TEST_SHMEM						?= 0
+TEST_32_MMU_ACCESS_PHYSICAL		?= 1
+TEST_MMU_MAPPING_SWAP			?= 1
 
 # Set build configuration here
 CONFIG_SYSTICK					?= 1

--- a/trch/main.c
+++ b/trch/main.c
@@ -133,6 +133,25 @@ int main ( void )
     struct dma *trch_dma = NULL;
 #endif // !CONFIG_TRCH_DMA
 
+#if TEST_32_MMU_ACCESS_PHYSICAL
+    if (test_32_mmu_access_physical_mwr(MMU_TEST_DATA_LO_0_ADDR, MMU_TEST_DATA_LO_1_ADDR, MMU_TEST_DATA_LO_SIZE))
+        panic("MMU 32-bit access test map-write-read");
+    else
+        printf("MMU map-write-read test success\n");
+
+    if (test_32_mmu_access_physical_wmr(MMU_TEST_DATA_LO_0_ADDR, MMU_TEST_DATA_LO_1_ADDR, MMU_TEST_DATA_LO_SIZE))
+        panic("MMU 32-bit access test write-map-read");
+    else
+        printf("MMU write-map-read test success\n");
+#endif
+
+#if TEST_MMU_MAPPING_SWAP
+    if (test_mmu_mapping_swap(MMU_TEST_DATA_LO_0_ADDR, MMU_TEST_DATA_LO_1_ADDR, MMU_TEST_DATA_HI_0_ADDR, MMU_TEST_DATA_LO_SIZE)) //map argument 1 to argument 3 then argument 2 to argument 3
+        panic("MMU mapping swap");
+    else
+        printf("MMU mapping swap test success\n");
+#endif
+
 #if CONFIG_RT_MMU
     if (rt_mmu_init())
         panic("RTPS/TRCH-HPPS MMU setup");

--- a/trch/tests/mmu.c
+++ b/trch/tests/mmu.c
@@ -1,8 +1,10 @@
 #include <stdint.h>
+#include <stdio.h>
 
 #include "printf.h"
 #include "hwinfo.h"
 #include "mem-map.h"
+#include "mmu.h"
 
 #include "test.h"
 
@@ -18,13 +20,282 @@ int test_rt_mmu()
 
     volatile uint32_t *addr = (volatile uint32_t *)RT_MMU_TEST_DATA_HI_1_WIN_ADDR;
     uint32_t val = 0xbeeff00d;
-    printf("%p <- %08x\r\n", addr, val);
+    printf("%p <- %08lx\r\n", addr, val);
     *addr = val;
 
     addr = (volatile uint32_t *)RT_MMU_TEST_DATA_HI_0_WIN_ADDR;
     val = 0xf00dbeef;
-    printf("%p <- %08x\r\n", addr, val);
+    printf("%p <- %08lx\r\n", addr, val);
     *addr = val;
 
     return 0;
+}
+
+int test_32_mmu_access_physical_mwr(uint32_t virt_write_addr, uint32_t phy_read_addr, unsigned mapping_sz){
+    //map-write-read test
+    //1. TRCH creates a mapping
+    //2. TRCH enables MMU
+    //3. TRCH writes to an address in the mapping created
+    //4. TRCH disables MMU
+    //5. TRCH reads the physical address where the data was written to and checks if the data is correct
+
+    //Test is successful if TRCH reads the correct data
+
+
+    _Bool success = 0;
+
+    struct mmu *mmu_32;
+    struct mmu_context *trch_ctx;
+    struct mmu_stream *trch_stream;
+    struct balloc *ba;
+
+    uint32_t val = 0xbeeff00d;
+    uint32_t old_val;
+
+    mmu_32 = mmu_create("RTPS/TRCH->HPPS", RTPS_TRCH_TO_HPPS_SMMU_BASE);
+
+    if (!mmu_32)
+        return 1;
+
+    mmu_disable(mmu_32); // might be already enabled if the core reboots
+
+    ba = balloc_create("32", (uint64_t *)RTPS_HPPS_PT_ADDR, RTPS_HPPS_PT_SIZE);
+
+    if (!ba)
+        goto cleanup_balloc;
+
+    trch_ctx = mmu_context_create(mmu_32, ba, MMU_PAGESIZE_4KB);
+    if (!trch_ctx) {
+        printf("test mmu 32-bit access physical map-write-read: trch context create failed\n");
+        goto cleanup_context;
+    }
+
+    trch_stream = mmu_stream_create(MASTER_ID_TRCH_CPU, trch_ctx);
+    if (!trch_stream) {
+        printf("test mmu 32-bit access physical map-write-read: trch stream create failed\n");
+        goto cleanup_stream;
+    }
+
+    if (mmu_map(trch_ctx, virt_write_addr, phy_read_addr,
+                          mapping_sz)) {
+        printf("test mmu 32-bit access physical map-write-read: mapping create failed\n");
+        goto cleanup_map;
+    }
+
+    mmu_enable(mmu_32);
+
+    old_val = *((uint32_t*)virt_write_addr);
+    *((uint32_t*)virt_write_addr) = val;
+
+    mmu_disable(mmu_32);
+
+    if (*((uint32_t*)phy_read_addr) == val) {
+        success = 1;
+    }
+    else {
+        printf("test mmu 32-bit access physical map-write-read: read wrong value\n");
+        success = 0;
+    }
+
+    mmu_enable(mmu_32);
+
+    *((uint32_t*)virt_write_addr) = old_val;
+
+    mmu_disable(mmu_32);
+
+    mmu_unmap(trch_ctx, virt_write_addr, mapping_sz);
+cleanup_map:
+    mmu_stream_destroy(trch_stream);
+cleanup_stream:
+    mmu_context_destroy(trch_ctx);
+cleanup_context:
+    balloc_destroy(ba);
+cleanup_balloc:
+    mmu_destroy(mmu_32);
+
+    if (success) {
+        return 0;
+    }
+    return 1;
+}
+
+int test_32_mmu_access_physical_wmr(uint32_t virt_read_addr, uint32_t phy_write_addr, unsigned mapping_sz){
+    //write-map-read test
+    //1. TRCH creates a mapping
+    //2. TRCH writes to a low physical address
+    //3. TRCH enables MMU
+    //4. TRCH reads the virtual address corresponding to the physical address written to and checks if data is correct
+
+    //Test is successful if TRCH reads the correct data
+
+
+    _Bool success = 0;
+
+    struct mmu *mmu_32;
+    struct mmu_context *trch_ctx;
+    struct mmu_stream *trch_stream;
+    struct balloc *ba;
+
+    uint32_t val = 0xbeeff00d;
+    uint32_t old_val;
+
+    mmu_32 = mmu_create("RTPS/TRCH->HPPS", RTPS_TRCH_TO_HPPS_SMMU_BASE);
+
+    if (!mmu_32)
+        return 1;
+
+    mmu_disable(mmu_32); // might be already enabled if the core reboots
+
+    ba = balloc_create("32", (uint64_t *)RTPS_HPPS_PT_ADDR, RTPS_HPPS_PT_SIZE);
+
+    if (!ba)
+        goto cleanup_balloc;
+
+    trch_ctx = mmu_context_create(mmu_32, ba, MMU_PAGESIZE_4KB);
+    if (!trch_ctx) {
+        printf("test mmu 32-bit access physical write-map-read: trch context create failed\n");
+        goto cleanup_context;
+    }
+
+    trch_stream = mmu_stream_create(MASTER_ID_TRCH_CPU, trch_ctx);
+    if (!trch_stream) {
+        printf("test mmu 32-bit access physical write-map-read: trch stream create failed\n");
+        goto cleanup_stream;
+    }
+
+    old_val = *((uint32_t*)phy_write_addr);
+    *((uint32_t*)phy_write_addr) = val;
+
+    if (mmu_map(trch_ctx, virt_read_addr, phy_write_addr,
+                          mapping_sz)) {
+        printf("test mmu 32-bit access physical write-map-read: mapping create failed\n");
+        goto cleanup_map;
+    }
+
+
+    mmu_enable(mmu_32);
+
+    if (*((uint32_t*)virt_read_addr) == val) {
+        success = 1;
+    }
+    else {
+        printf("test mmu 32-bit access physical write-map-read: read wrong value\n");
+        success = 0;
+    }
+
+    *((uint32_t*)virt_read_addr) = old_val;
+
+    mmu_disable(mmu_32);
+
+    mmu_unmap(trch_ctx, virt_read_addr, mapping_sz);
+cleanup_map:
+    mmu_stream_destroy(trch_stream);
+cleanup_stream:
+    mmu_context_destroy(trch_ctx);
+cleanup_context:
+    balloc_destroy(ba);
+cleanup_balloc:
+    mmu_destroy(mmu_32);
+
+    if (success) {
+        return 0;
+    }
+    return 1;
+}
+
+int test_mmu_mapping_swap(uint32_t virt_write_addr, uint32_t virt_read_addr, uint64_t phy_addr, unsigned mapping_sz){
+    //In this test,
+    //1. TRCH creates a mapping from virt_write_addr to phy_addr
+    //2. TRCH enables MMU
+    //3. TRCH writes data to virt_write_addr (effectively writing to phy_addr)
+    //4. TRCH unmaps the mapping created in step 1
+    //5. TRCH maps virt_read_addr to phy_addr
+    //6. TRCH reads virt_read_addr, checking if data is same as in step 3
+
+    //Test is successful if TRCH reads the correct data
+
+
+    _Bool success = 0;
+
+    struct mmu *mmu_32;
+    struct mmu_context *trch_ctx;
+    struct mmu_stream *trch_stream;
+    struct balloc *ba;
+
+    uint32_t val = 0xbeeff00d;
+    uint32_t old_val;
+
+    mmu_32 = mmu_create("RTPS/TRCH->HPPS", RTPS_TRCH_TO_HPPS_SMMU_BASE);
+
+    if (!mmu_32)
+        return 1;
+
+    mmu_disable(mmu_32); // might be already enabled if the core reboots
+
+    ba = balloc_create("32", (uint64_t *)RTPS_HPPS_PT_ADDR, RTPS_HPPS_PT_SIZE);
+
+    if (!ba)
+        goto cleanup_balloc;
+
+    trch_ctx = mmu_context_create(mmu_32, ba, MMU_PAGESIZE_4KB);
+    if (!trch_ctx) {
+        printf("test mmu mapping swap: trch context create failed\n");
+        goto cleanup_context;
+    }
+
+    trch_stream = mmu_stream_create(MASTER_ID_TRCH_CPU, trch_ctx);
+    if (!trch_stream) {
+        printf("test mmu mapping swap: trch stream create failed\n");
+        goto cleanup_stream;
+    }
+
+    if (mmu_map(trch_ctx, virt_write_addr, phy_addr,
+                          mapping_sz)) {
+        printf("test mmu mapping swap: addr_from_1->addr_to mapping create failed\n");
+        goto cleanup_map;
+    }
+
+    mmu_enable(mmu_32);
+
+    old_val = *((uint32_t*)virt_write_addr);
+    *((uint32_t*)virt_write_addr) = val;
+
+    mmu_disable(mmu_32);
+
+    mmu_unmap(trch_ctx, virt_write_addr, mapping_sz);
+
+    if (mmu_map(trch_ctx, virt_read_addr, phy_addr,
+                          mapping_sz)) {
+        printf("test mmu mapping swap: addr_from_1->addr_to mapping create failed\n");
+        goto cleanup_map;
+    }
+
+    mmu_enable(mmu_32);
+
+    if (*((uint32_t*)virt_read_addr) == val) {
+        success = 1;
+    }
+    else {
+        printf("test mmu mapping swap: read wrong value %lx \n", *((uint32_t*)virt_read_addr));
+        success = 0;
+    }
+
+    *((uint32_t*)virt_read_addr) = old_val;
+
+    mmu_disable(mmu_32);
+
+    mmu_unmap(trch_ctx, virt_read_addr, mapping_sz);
+cleanup_map:
+    mmu_stream_destroy(trch_stream);
+cleanup_stream:
+    mmu_context_destroy(trch_ctx);
+cleanup_context:
+    balloc_destroy(ba);
+cleanup_balloc:
+    mmu_destroy(mmu_32);
+
+    if (success) {
+        return 0;
+    }
+    return 1;
 }

--- a/trch/tests/test.h
+++ b/trch/tests/test.h
@@ -9,5 +9,8 @@ int test_wdts();
 int test_etimer();
 int test_core_rti_timer();
 int test_shmem();
+int test_32_mmu_access_physical_mwr(uint32_t addr_from, uint32_t addr_to, unsigned mapping_sz); //map -> write -> read test
+int test_32_mmu_access_physical_wmr(uint32_t addr_from, uint32_t addr_to, unsigned mapping_sz); //write -> map -> read test
+int test_mmu_mapping_swap(uint32_t addr_from_1, uint32_t addr_from_2, uint64_t addr_to, unsigned mapping_sz);
 
 #endif // TEST_H


### PR DESCRIPTION
Added three MMU tests. Two are for testing low address read/writes through MMU and one for testing mappings to high addresses. Changed Makefile, Makefile configuration, main.c and memory map accordingly. Tests run automatically at TRCH startup if Makefile configuration is set. Tests are defaulted to run currently. On test failure, panic() will be called.